### PR TITLE
Keep block

### DIFF
--- a/postbuild
+++ b/postbuild
@@ -47,7 +47,7 @@ program
 .option('-o, --output <output>', 'Output file (defaults to input when omitted)')
 .option('-c, --css <css>', 'css file(s) to inject (file or directory). Wildcards can be used with quotation: \'**/*.css\'')
 .option('-j, --js <js>', 'js file(s) to inject (file or directory). Wildcards can be used with quotation: \'**/*.js\'')
-.option('-r, --remove <remove>', 'Remove condition')
+.option('-r, --remove <remove>', 'Remove and keep condition')
 .option('-g, --ignore <path>', 'Prefix to remove from the injected filenames')
 .option('-H, --hash', 'Inject git hash of current commit')
 .option('-e, --etag', 'appends "?etag=fileHash" to every import (link, script) to avoid undesired caching in new deployments')
@@ -145,11 +145,13 @@ if(program.hash) {
 const replaceJs = replaceFunc(jsFiles);
 const replaceCss = replaceFunc(cssFiles);
 const injectHash = replaceFunc(`<!-- ${revision} -->`)
-const regex = new RegExp(`(<!\\-\\- remove:${removeCondition} \\-\\->)([\\s\\S]*?)(<!\\-\\- endremove \\-\\->)`, 'gm');
+const keepRegex = new RegExp(`(<!\\-\\- keep:((?!${removeCondition}).)* \\-\\->)([\\s\\S]*?)(<!\\-\\- endkeep \\-\\->)`, 'gm');
+const removeRegex = new RegExp(`(<!\\-\\- remove:${removeCondition} \\-\\->)([\\s\\S]*?)(<!\\-\\- endremove \\-\\->)`, 'gm');
 
 fs.createReadStream(program.input)
 .pipe(replaceStream(/(<!\-\- inject:js \-\->)([\s\S]*?)(<!\-\- endinject \-\->)/gm, replaceJs))
 .pipe(replaceStream(/(<!\-\- inject:css \-\->)([\s\S]*?)(<!\-\- endinject \-\->)/gm, replaceCss))
 .pipe(replaceStream(/(<!\-\- inject:git\-hash \-\->)/gm, injectHash))
-.pipe(replaceStream(regex, ''))
+.pipe(replaceStream(keepRegex, ''))
+.pipe(replaceStream(removeRegex, ''))
 .pipe(fs.createWriteStream(program.output));

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,7 @@ Inspired by [gulp-inject](https://www.npmjs.com/package/gulp-inject) and [gulp-r
 This module injects css and javascript files between markers placed in an html file or removes code between markers.
 It can take a single file or a directory of files which will be transformed to strings and injected.
 It removes code between markers so you can for example remove livereload code which is not needed in a production environment.
+As well as removing code it can keep code between markers so you can had environment specific code such as Sentry which is not needed in development or SIT environments. 
 It can also inject the current git commit hash into the HTML as a comment so it is easily visible which commit is currently 
 deployed.
 
@@ -33,6 +34,10 @@ Place the markers in your html file to inject or remove code:
      <script src="http://localhost:35729/livereload.js?snipver=1"></script>
      <!-- endremove -->
 
+     <!-- keep:production -->
+     <script src="https://browser.sentry-cdn.com/4.4.2/bundle.min.js" crossorigin="anonymous"></script>
+     <!-- endkeep -->
+
    </body>
    </html>
    <!-- inject:git-hash -->
@@ -48,7 +53,7 @@ This way you can replace the regular files used in a development environment wit
     -o, --output <output>  Output file (defaults to input when omitted)
     -c, --css <css>        css file(s) to inject (file or directory). Wildcards can be used with quotation: '**/*.css'
     -j, --js <js>          js file(s) to inject (file or directory). Wildcards can be used with quotation: '**/*.js'
-    -r, --remove <remove>  Remove condition
+    -r, --remove <remove>  Remove and keep condition
     -g, --ignore <path>    Prefix to remove from the injected filenames
     -H, --hash             Inject git hash of current commit
     -e, --etag             Appends "?etag=fileHash" to every import (link, script) to avoid undesired caching in new deployments
@@ -87,6 +92,10 @@ will result in the file `dist/index.html`:
      <script src="dist/js/build.4567def.js"></script>
      <!-- endinject -->
 
+     <!-- keep:production -->
+     <script src="https://browser.sentry-cdn.com/4.4.2/bundle.min.js" crossorigin="anonymous"></script>
+     <!-- endkeep -->
+
    </body>
    </html>
    <!-- b64f022ae51d87a411c4608f403f3216ee028d03 -->
@@ -99,6 +108,14 @@ will result in the file `dist/index.html`:
      <!-- endremove -->
 ```
 *has been removed.*
+
+*But the code*
+```
+     <!-- keep:production -->
+     <script src="https://browser.sentry-cdn.com/4.4.2/bundle.min.js" crossorigin="anonymous"></script>
+     <!-- endkeep -->
+```
+*has NOT been removed.*
 
 *The comment*
 ```
@@ -129,6 +146,10 @@ results in:
      <script src="dist/js/build.4567def.js"></script>
      <!-- endinject -->
 
+     <!-- keep:production -->
+     <script src="https://browser.sentry-cdn.com/4.4.2/bundle.min.js" crossorigin="anonymous"></script>
+     <!-- endkeep -->
+
    </body>
    </html>
 ```
@@ -153,6 +174,10 @@ If the -e, --etag is specified the output will be
      <!-- inject:js -->
      <script src="dist/js/build.4567def.js?etag=9fffaf9de332d9848ab34bbc3434d34341"></script>
      <!-- endinject -->
+
+     <!-- keep:production -->
+     <script src="https://browser.sentry-cdn.com/4.4.2/bundle.min.js" crossorigin="anonymous"></script>
+     <!-- endkeep -->
 
    </body>
    </html>

--- a/tests/test.js
+++ b/tests/test.js
@@ -48,6 +48,10 @@ const setup = () => {
                     <!-- remove:development -->
                     <script src="lib/profiler.js"></script>
                     <!-- endremove -->
+
+                    <!-- keep:development -->
+                    <script src="lib/dev_profiler.js"></script>
+                    <!-- endkeep -->
             
                     <script src="/src/jquery.js"></script>
                     
@@ -58,7 +62,14 @@ const setup = () => {
                     <!-- remove:production -->
                     <script src="http://localhost:35729/livereload.js?snipver=1"></script>
                     <!-- endremove -->
+
+                    <!-- keep:production -->
+                    <script src="http://localhost:35729/prod_livereload.js?snipver=1"></script>
+                    <!-- endkeep -->
                     
+                    <!-- keep:unknown -->
+                    <script src="http://localhost:35729/unknown_livereload.js?snipver=1"></script>
+                    <!-- endkeep -->
                     
                 </body>
             </html>
@@ -234,28 +245,40 @@ test('test injection of javascripts with wildcard with ignore', (t) => {
     });
 });
 
-test('test removal of development code', (t) => {
+test('test keep and remove development code', (t) => {
     exec(`./postbuild -i ${inputFile} -o ${outputFile} -r development`, (err) => {
-        const devRegex = new RegExp('(<!\\-\\- remove:development \\-\\->)([\\s\\S]*?)(<!\\-\\- endremove \\-\\->)');
-        const prodRegex = new RegExp('(<!\\-\\- remove:production \\-\\->)([\\s\\S]*?)(<!\\-\\- endremove \\-\\->)');
-        
+        const devRemoveRegex = new RegExp('(<!\\-\\- remove:development \\-\\->)([\\s\\S]*?)(<!\\-\\- endremove \\-\\->)');
+        const prodRemoveRegex = new RegExp('(<!\\-\\- remove:production \\-\\->)([\\s\\S]*?)(<!\\-\\- endremove \\-\\->)');
+        const devKeepRegex = new RegExp('(<!\\-\\- keep:development \\-\\->)([\\s\\S]*?)(<!\\-\\- endkeep \\-\\->)');
+        const prodKeepRegex = new RegExp('(<!\\-\\- keep:production \\-\\->)([\\s\\S]*?)(<!\\-\\- endkeep \\-\\->)');
+        const unknownKeepRegex = new RegExp('(<!\\-\\- keep:unknown \\-\\->)([\\s\\S]*?)(<!\\-\\- endkeep \\-\\->)');
+
         fs.readFile(`${outputFile}`, (err, data) => {
-            t.equal(false, devRegex.test(data), `expect development code to be removed`);
-            t.equal(true, prodRegex.test(data), `expect production code to not be removed`);
-            
+            t.equal(false, devRemoveRegex.test(data), `expect development code to be removed`);
+            t.equal(true, prodRemoveRegex.test(data), `expect production code to not be removed`);
+            t.equal(true, devKeepRegex.test(data), `expect development code to be kept`);
+            t.equal(false, prodKeepRegex.test(data), `expect production code to not be kept`);
+            t.equal(false, unknownKeepRegex.test(data), `expect unknown code to not be kept`);
+
             t.end();
         });
     });
 });
 
-test('test removal of production code', (t) => {
+test('test keep and remove production code', (t) => {
     exec(`./postbuild -i ${inputFile} -o ${outputFile} -r production`, (err) => {
-        const prodRegex = new RegExp('(<!\\-\\- remove:production \\-\\->)([\\s\\S]*?)(<!\\-\\- endremove \\-\\->)');
-        const devRegex = new RegExp('(<!\\-\\- remove:development \\-\\->)([\\s\\S]*?)(<!\\-\\- endremove \\-\\->)');
+        const prodRemoveRegex = new RegExp('(<!\\-\\- remove:production \\-\\->)([\\s\\S]*?)(<!\\-\\- endremove \\-\\->)');
+        const devRemoveRegex = new RegExp('(<!\\-\\- remove:development \\-\\->)([\\s\\S]*?)(<!\\-\\- endremove \\-\\->)');
+        const prodKeepRegex = new RegExp('(<!\\-\\- keep:production \\-\\->)([\\s\\S]*?)(<!\\-\\- endkeep \\-\\->)');
+        const devKeepRegex = new RegExp('(<!\\-\\- keep:development \\-\\->)([\\s\\S]*?)(<!\\-\\- endkeep \\-\\->)');
+        const unknownKeepRegex = new RegExp('(<!\\-\\- keep:unknown \\-\\->)([\\s\\S]*?)(<!\\-\\- endkeep \\-\\->)');
 
         fs.readFile(`${outputFile}`, (err, data) => {
-            t.equal(false, prodRegex.test(data), `expect production code to be removed`);
-            t.equal(true, devRegex.test(data), `expect development code to not be removed`);
+            t.equal(false, prodRemoveRegex.test(data), `expect production code to be removed`);
+            t.equal(true, devRemoveRegex.test(data), `expect development code to not be removed`);
+            t.equal(true, prodKeepRegex.test(data), `expect production code to be kept`);
+            t.equal(false, devKeepRegex.test(data), `expect development code to not be kept`);
+            t.equal(false, unknownKeepRegex.test(data), `expect unknown code to not be kept`);
 
             t.end();
         });


### PR DESCRIPTION
This functionality is the opposite of the "remove" markers.  It will keep code with the marker matching the remove string.

Where "remove" is useful for code that is for all environments except one, "keep" is useful for code that is for only one environment (such as a production error logging system).

This PR will likely have merge conflicts with my previous PR.

Please let me know if you do not wish to add this functionality or if it requires any changes before merge. 